### PR TITLE
Support for XYplorer scripting language

### DIFF
--- a/lib/structure-view.js
+++ b/lib/structure-view.js
@@ -45,7 +45,12 @@ export default class StructureView {
               return i.getPath() === this.lastFile;
             });
           if (editor) {
-            editor.setCursorScreenPosition(position);
+            // lines can be soft-wrapped
+            if (editor.isSoftWrapped()) {
+              editor.setCursorBufferPosition(position);
+            } else {
+                editor.setCursorScreenPosition(position);
+            }
             editor.scrollToCursorPosition();
           }
         },

--- a/lib/structure-view.js
+++ b/lib/structure-view.js
@@ -49,7 +49,7 @@ export default class StructureView {
             if (editor.isSoftWrapped()) {
               editor.setCursorBufferPosition(position);
             } else {
-                editor.setCursorScreenPosition(position);
+              editor.setCursorScreenPosition(position);
             }
             editor.scrollToCursorPosition();
           }

--- a/lib/tag-generators/.ctags
+++ b/lib/tag-generators/.ctags
@@ -85,33 +85,23 @@
 --regex-JavaScript=/(,|(;|^)[ \t]*(var|let|const|([A-Za-z_$][A-Za-z0-9_$.]*\.)+))[ \t]*([A-Za-z_$][A-Za-z0-9_$.]*)[ \t]*=[ \t]*[0-9]+/\5/,number/
 --regex-JavaScript=/(,|(;|^)[ \t]*(var|let|const|([A-Za-z_$][A-Za-z0-9_$.]*\.)+))[ \t]*([A-Za-z_$][A-Za-z0-9_$.]*)[ \t]*=[ \t]*null/\5/,null/
 --regex-JavaScript=/(,|(;|^)[ \t]*(var|let|const|([A-Za-z_$][A-Za-z0-9_$.]*\.)+))[ \t]*([A-Za-z_$][A-Za-z0-9_$.]*)[ \t]*=[ \t]*undefined/\5/,undefined/
-
 --regex-JavaScript=/(,|(;|^)[ \t]*(var|let|([A-Za-z_$][A-Za-z0-9_$.]*\.)+))[ \t]*([A-Za-z_$][A-Za-z0-9_$.]*)[ \t]*=[ \t]*[^tfn0-9"'{\[]+([,;=]|$)/\5/,unknown/
-
 --regex-JavaScript=/(,|(;|^)[ \t]*(var|let|([A-Za-z_$][A-Za-z0-9_$.]*\.)+))[ \t]*([A-Za-z_$][A-Za-z0-9_$.]*)[ \t]*=[ \t]*.+([,;=]|$)/\5/,variable/
 --regex-JavaScript=/(,|(;|^)[ \t]*(var|let|([A-Za-z_$][A-Za-z0-9_$.]*\.)+))[ \t]*([A-Za-z_$][A-Za-z0-9_$.]*)[ \t]*[ \t]*([,;]|$)/\5/,undefined/
 --regex-JavaScript=/(,|(;|^)[ \t]*)const[ \t]*([A-Za-z_$][A-Za-z0-9_$]*)[ \t]*=[ \t]*.+([,;=]|$)/\3/,constant/
-
-
 --regex-JavaScript=/(,|(;|^)[ \t]*(var|let|([A-Za-z_$][A-Za-z0-9_$.]*\.)*))[ \t]*([A-Za-z_$][A-Za-z0-9_$]*)[ \t]*=[ \t]*function[ \t]*\(/\5/,function-expression/
 --regex-JavaScript=/(,|(;|^))[ \t]*(([A-Za-z_$][A-Za-z0-9_$.]*\.)+prototype\.)[ \t]*([A-Za-z_$][A-Za-z0-9_$]*)[ \t]*=[ \t]*function[ \t]*\(/\4\5/,prototype-method/
 --regex-JavaScript=/(,|^|\*\/)[ \t]*([A-Za-z_$][A-Za-z0-9_$]*)[ \t]*:[ \t]*function[ \t]*\(/\2/,object-method/
-
-
 --regex-JavaScript=/function[ \t]+([A-Za-z_$][A-Za-z0-9_$]*)[ \t]*\([^)]*\)/\1/,function-declaration/
-
 --regex-JavaScript=/(,|^|\*\/)[ \t]*(while|if|for|switch|function|([A-Za-z_$][A-Za-z0-9_$]*))[ \t]*\([^)]*\)[ \t]*\{/\3/,function/
-
 --regex-JavaScript=/(,|^|\*\/|\{)[ \t]*get[ \t]+([A-Za-z_$][A-Za-z0-9_$]*)[ \t]*\([ \t]*\)[ \t]*\{/get \2/,getter/
 --regex-JavaScript=/(,|^|\*\/|\{)[ \t]*set[ \t]+([A-Za-z_$][A-Za-z0-9_$]*)[ \t]*\([ \t]*([A-Za-z_$][A-Za-z0-9_$]*)?[ \t]*\)[ \t]*\{/set \2/,setter/
-
 --regex-JavaScript=/(,|^|\*\/)[ \t]*([A-Za-z_$][A-Za-z0-9_$]*)[ \t]*:[ \t]*\{/\2/,object/
 --regex-JavaScript=/(,|^|\*\/)[ \t]*([A-Za-z_$][A-Za-z0-9_$]*)[ \t]*:[ \t]*\[/\2/,array/
 --regex-JavaScript=/(,|^|\*\/)[ \t]*([A-Za-z_$][A-Za-z0-9_$]*)[ \t]*:[ \t]*[^"]'[^']*/\2/,string/
 --regex-JavaScript=/(,|^|\*\/)[ \t]*([A-Za-z_$][A-Za-z0-9_$]*)[ \t]*:[ \t]*(true|false)/\2/,boolean/
 --regex-JavaScript=/(,|^|\*\/)[ \t]*([A-Za-z_$][A-Za-z0-9_$]*)[ \t]*:[ \t]*[0-9]+/\2/,number/
 --regex-JavaScript=/(,|^|\*\/)[ \t]*([A-Za-z_$][A-Za-z0-9_$]*)[ \t]*:[ \t]*[^=]+([,;]|$)/\2/,variable/
-
 --regex-javascript=/^[ \t]*(var|let|const)[ \t]+([A-Z][A-Za-z0-9_$]+)[ \t]*=[ \t]*function/\2/C,class/
 --regex-javascript=/^[ \t]*class[ \t]+([A-Za-z0-9_$]+)/\1/C,class/
 
@@ -188,3 +178,8 @@
 --langdef=ini
 --langmap=ini:.ini
 --regex-ini=/^[ \t]*(\[.+\])[ \t]*$/\1/t,generics/
+
+--langdef=XYplorer
+--langmap=XYplorer:.xys
+--langmap=XYplorer:+.xyi
+--regex-XYplorer=/^function[ \t]+([a-zA-Z0-9_]*)[ \t]*\([^)]*\)[ \t]*\{/\1/,function/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Structure View for ATOM, just like Outline view in Eclipse or Structure tool window in IDEA / WebStorm, provides quick navigation for symbols of source code with a tree view.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gitarian/structure-view"
+    "url": "https://github.com/alibaba/structure-view"
   },
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Structure View for ATOM, just like Outline view in Eclipse or Structure tool window in IDEA / WebStorm, provides quick navigation for symbols of source code with a tree view.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alibaba/structure-view"
+    "url": "https://github.com/gitarian/structure-view"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Hi John,

as announced here's my pull request (never did it before, so I hope all, this description in particular, is fine).

**lib/tag-generators/.ctags (167166d)**: here I added - the most simple - support for my beloved Windows FileManager XYplorer scripting engine (https://www.xyplorer.com/tour.php?page=scripting). That's just to have the basic function outline working.
I'm planning to use this opportunity to dive deeper into _TypeScript_ by writing a dedicated (simple) parser to also support nested control structures (will start just with loops). Maybe this could become a base for a Language Server later on...

**lib/structure-view.js (a091db2)**: here I added support for soft-wrapped editors, otherwise the editor-jump from the symbol will become out of line quite easily with soft-wrap==ON.

Now I hope this request is formally ok (or should I better had attached the source files). ;-)

Let me know what you think.

Cheers,
G.

edit: Strange, obviously ALL my commits are considered to be merge back by the GitHub system. During preparation I already was wondering why I couldn't select the single commits. Is this the normal way?


