### PR TITLE
Add settings to hide variables and properties

### DIFF
--- a/lib/structure-view.js
+++ b/lib/structure-view.js
@@ -196,6 +196,9 @@ export default class StructureView {
     let array = [],
       letter;
 
+    let ShowVariables = atom.config.get('structure-view.ShowVariables');
+    let ShowProperties = atom.config.get('structure-view.ShowProperties');
+
     _.forEach(data, item => {
       switch (item.type) {
 
@@ -204,9 +207,13 @@ export default class StructureView {
           letter = 'S';
           break;
         case 'prop':      // CSS
-          letter = 'P';
+          if (ShowProperties)
+          {
+            letter = 'P';
+          }else{
+            return;
+          }          
           break;
-
         case 'elem':      // HTML
           letter = '';
           break;
@@ -227,9 +234,13 @@ export default class StructureView {
         case 'var':       // JS
         case 'variable':  // C
         case 'macro':
-          letter = 'V';
+          if (ShowVariables)
+          {
+              letter = 'V';
+          }else{
+              return;
+          }
           break;
-
         default:
           letter = 'U';
           break;
@@ -238,21 +249,31 @@ export default class StructureView {
       if (item.type === 'elem') iconTpl = `<span class="icon icon-code"></span>`;
       else iconTpl = `<div class="icon-circle icon-${letter}"><span>${letter}</span></div>`;
 
-      array.push(item.child ?
-        `<li node-id="${item.id}" class="list-nested-item expanded" title="${item.name}">
-                    <div class="list-item symbol-mixed-block">
-                        ${iconTpl}
-                        <span>${item.name}</span>
-                    </div>
-                    <ol class="list-tree">${self.treeGenerator(item.child)}</ol>
-                </li>` :
-        `<li node-id="${item.id}" class="list-item" title="${item.name}">
-                    <div class="symbol-mixed-block">
-                        ${iconTpl}
-                        <span>${item.name}</span>
-                    </div>
-                </li>`
-      );
+        let entry = `<li node-id="${item.id}" class="list-item" title="${item.name}">
+          <div class="symbol-mixed-block">
+              ${iconTpl}
+              <span>${item.name}</span>
+          </div>
+        </li>`;
+
+        if (item.child)
+        {
+            let childContent = self.treeGenerator(item.child);
+
+            if (childContent.length != 0)
+            {
+            entry = `<li node-id="${item.id}" class="list-nested-item expanded" title="${item.name}">
+                        <div class="list-item symbol-mixed-block">
+                            ${iconTpl}
+                            <span>${item.name}</span>
+                        </div>
+                        <ol class="list-tree">${childContent}</ol>
+                    </li>`;
+            }
+        }
+
+        array.push(entry);
+
     });
     return array.join('');
   }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,19 @@
       "description": "Enable this feature to have Atom automatically move the focus in the Structure View to the node that corresponds to the code where the cursor is currently positioned in the editor.",
       "type": "boolean",
       "default": false
-    }
+    },
+    "ShowVariables": {
+      "title": "Show Variables",
+      "description": "Show Variables",
+      "type": "boolean",
+      "default": true
+    },
+    "ShowProperties": {
+      "title": "Show Properties",
+      "description": "Show Properties",
+      "type": "boolean",
+      "default": true
+    }    
   },
   "keywords": [
     "taglist",


### PR DESCRIPTION
Variables(JS) and properties(CSS) are not really part of structure of file and hiding them makes the tree cleaner and easier to navigate.

