### PR TITLE
Add support for Ruby RSpec and MiniTest

### DIFF
--- a/lib/structure-view.js
+++ b/lib/structure-view.js
@@ -275,7 +275,11 @@ export default class StructureView {
           break;
 
         case 'class':     // JS
+        case 'context':   // Ruby
           letter = 'C';
+          break;
+        case 'describe':  // Ruby
+          letter = 'D';
           break;
         case 'import':    // JS
           letter = 'I';

--- a/lib/tag-generators/.ctags
+++ b/lib/tag-generators/.ctags
@@ -51,6 +51,8 @@
 --langmap=C++:+.mm
 
 --langmap=Ruby:+(Rakefile)
+--regex-Ruby=/^[ \t]*describe[ \t]*['":]?([^'"]*)['"]?[ \t]*do/\1/d,describe/
+--regex-Ruby=/^[ \t]*context[ \t]*['":]?([^'"]*)['"]?[ \t]*do/\1/c,context/
 
 --langmap=Php:+.module
 

--- a/styles/structure-view.less
+++ b/styles/structure-view.less
@@ -64,6 +64,10 @@
     background-color: #40b4e5;
   }
 
+  div.icon-D {
+    background-color: #f45ba3;
+  }
+
   div.icon-I,
   div.icon-V {
     background-color: #fc6d26;


### PR DESCRIPTION
This adds support for RSpec and MiniTest in Ruby to bring the power of structure-view to potentially hard to navigate test suites.