### PR TITLE
Change keymap from ctrl-o to ctrl-alt-s

### DIFF
--- a/keymaps/yang-plugin-structure-view.json
+++ b/keymaps/yang-plugin-structure-view.json
@@ -1,5 +1,5 @@
 {
     "atom-workspace": {
-        "ctrl-o": "structure-view:toggle"
+        "ctrl-alt-s": "structure-view:toggle"
     }
 }


### PR DESCRIPTION
By default, ctrl-o keybinding is reserved for opening a file, replacing it is not a good idea: The user expects the file selection dialog to come up. A better alternative could be ctrl-alt-s, which also includes the first letter of the word "structure".